### PR TITLE
Check for image extensions

### DIFF
--- a/BrowserImageSlideshow.html
+++ b/BrowserImageSlideshow.html
@@ -36,14 +36,17 @@ https://obsproject.com/forum/threads/browser-image-slideshow.110157/
 // 1: Alphabetical order
 // 2: Alphabetical order (start on random image)
 
+// common extensions from here https://developer.mozilla.org/en-US/docs/Web/Media/Formats/Image_types
+const imageExtensions = ["apng", "avif", "gif", "jpg", "jpeg", "jfif", "pjpeg", "pjp", "png", "svg", "webp", "bmp", "ico", "cur"];
+
 // setup image src strings
 let images = imageNamesStr.split("\n");
 images.shift();
 images.pop();
 for (let i = images.length-1; i >= 0; i--) {
-    // remove js, sh, or directory
-    let remove = images[i].includes(".js") || images[i].includes(".sh") || !images[i].includes(".") || images[i].includes(".git");
-    if (remove) {
+    let fileName = images[i];
+    // remove anything that's not an image
+    if (!imageExtensions.some(v => fileName.includes("."+v))) {
         images.splice(i, 1);
     }
 }


### PR DESCRIPTION
Rather than filter out a few non-image extensions (such as git, js, etc), check from a list of supported image extensions for the browser and remove any files that do not contain those image extensions.