### PR TITLE
Allow diacritics (accented characters) in image captions

### DIFF
--- a/BrowserImageSlideshow.html
+++ b/BrowserImageSlideshow.html
@@ -1,4 +1,5 @@
 <!DOCTYPE html>
+<meta charset="UTF-8">
 <!--
 
 BrowserImageSlideshow


### PR DESCRIPTION
Enable UTF-8 so that captions of images with titles containing diacritics (accented characters) such as diakrínō or διακρίνω are correctly rendered.